### PR TITLE
Feat/add more options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acid-tango/lokalise-downloader",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A simple npm package for downloading translations from Lokalise",
   "main": "dist/fetcher.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "dependencies": {
     "adm-zip": "^0.5.9",
     "change-case": "^4.1.2",
+    "commander": "^9.0.0",
     "node-fetch": "^2.6.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1416,6 +1416,11 @@ commander@^4.0.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
+commander@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.0.0.tgz#86d58f24ee98126568936bd1d3574e0308a99a40"
+  integrity sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
```
lokalise-downloader --help
Usage: lokalise-downloader [options]

Options:
  -k, --api-key <apiKey>           lokalise API key (env: LOKALISE_API_KEY)
  -p, --project-id <projectId>     lokalise project id (env: LOKALISE_PROJECT_ID)
  -t, --tags <tags>                lokalise project tags
  -d, --destination <destination>  destination folder (default: "./src/locales")
  -h, --help    
```